### PR TITLE
Prevent ArrayIndexOutOfBoundsException in JwtTokenFilter.getTokenString

### DIFF
--- a/src/main/java/io/spring/api/security/JwtTokenFilter.java
+++ b/src/main/java/io/spring/api/security/JwtTokenFilter.java
@@ -48,9 +48,9 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     }
 
     private Optional<String> getTokenString(String header) {
-        if (header == null)
+        if (header == null) {
             return Optional.empty();
-        else {
+        } else {
             String[] split = header.split(" ");
             if (split.length < 2) {
                 return Optional.empty();

--- a/src/main/java/io/spring/api/security/JwtTokenFilter.java
+++ b/src/main/java/io/spring/api/security/JwtTokenFilter.java
@@ -48,10 +48,15 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     }
 
     private Optional<String> getTokenString(String header) {
-        if (header == null || header.split("").length < 2) {
+        if (header == null)
             return Optional.empty();
-        } else {
-            return Optional.ofNullable(header.split(" ")[1]);
+        else {
+            String[] split = header.split(" ");
+            if (split.length < 2) {
+                return Optional.empty();
+            } else {
+                return Optional.ofNullable(split[1]);
+            }
         }
     }
 }

--- a/src/main/java/io/spring/api/security/WebSecurityConfig.java
+++ b/src/main/java/io/spring/api/security/WebSecurityConfig.java
@@ -36,7 +36,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             .antMatchers(HttpMethod.GET, "/articles/feed").authenticated()
             .antMatchers(HttpMethod.POST, "/users", "/users/login").permitAll()
             .antMatchers(HttpMethod.GET, "/articles/**", "/profiles/**", "/tags").permitAll()
-            .anyRequest().authenticated();
+            .antMatchers("/h2-console", "/h2-console/**")
+            .permitAll()
+            .anyRequest().authenticated()
+            .and()
+            .headers().frameOptions().sameOrigin();
 
         http.addFilterBefore(jwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,4 +5,5 @@ jwt.sessionTime=86400
 mybatis.config-location=classpath:mybatis-config.xml
 mybatis.mapper-locations=mapper/*.xml
 logging.level.io.spring.infrastructure.mybatis.readservice.ArticleReadService=DEBUG
-spring.h2.console.enabled=true
+# Uncomment the following line to enable and allow access to the h2-console
+#spring.h2.console.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,4 @@ jwt.sessionTime=86400
 mybatis.config-location=classpath:mybatis-config.xml
 mybatis.mapper-locations=mapper/*.xml
 logging.level.io.spring.infrastructure.mybatis.readservice.ArticleReadService=DEBUG
+spring.h2.console.enabled=true


### PR DESCRIPTION
Hi! I was looking through your code (very helpful, thanks for the example) and noticed a typo in `JwtTokenFilter.getTokenString`: There's a missing space in the if-check for `header.split("").length`.