### PR TITLE
Remove unnecessary annotation on MyBatis mapper interface

### DIFF
--- a/src/main/java/io/spring/infrastructure/mybatis/mapper/ArticleFavoriteMapper.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/mapper/ArticleFavoriteMapper.java
@@ -3,10 +3,8 @@ package io.spring.infrastructure.mybatis.mapper;
 import io.spring.core.favorite.ArticleFavorite;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Component;
 
 @Mapper
-@Component
 public interface ArticleFavoriteMapper {
     ArticleFavorite find(@Param("articleId") String articleId, @Param("userId") String userId);
 

--- a/src/main/java/io/spring/infrastructure/mybatis/mapper/ArticleMapper.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/mapper/ArticleMapper.java
@@ -4,9 +4,7 @@ import io.spring.core.article.Article;
 import io.spring.core.article.Tag;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Component;
 
-@Component
 @Mapper
 public interface ArticleMapper {
     void insert(@Param("article") Article article);

--- a/src/main/java/io/spring/infrastructure/mybatis/mapper/CommentMapper.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/mapper/CommentMapper.java
@@ -3,9 +3,7 @@ package io.spring.infrastructure.mybatis.mapper;
 import io.spring.core.comment.Comment;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Component;
 
-@Component
 @Mapper
 public interface CommentMapper {
     void insert(@Param("comment") Comment comment);

--- a/src/main/java/io/spring/infrastructure/mybatis/mapper/UserMapper.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/mapper/UserMapper.java
@@ -4,9 +4,7 @@ import io.spring.core.user.FollowRelation;
 import io.spring.core.user.User;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Component;
 
-@Component
 @Mapper
 public interface UserMapper {
     void insert(@Param("user") User user);

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/ArticleFavoritesReadService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/ArticleFavoritesReadService.java
@@ -4,13 +4,11 @@ import io.spring.application.data.ArticleFavoriteCount;
 import io.spring.core.user.User;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Set;
 
 @Mapper
-@Component
 public interface ArticleFavoritesReadService {
     boolean isUserFavorite(@Param("userId") String userId, @Param("articleId") String articleId);
 

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/ArticleReadService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/ArticleReadService.java
@@ -4,11 +4,9 @@ import io.spring.application.Page;
 import io.spring.application.data.ArticleData;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
 @Mapper
 public interface ArticleReadService {
     ArticleData findById(@Param("id") String id);

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/CommentReadService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/CommentReadService.java
@@ -3,11 +3,9 @@ package io.spring.infrastructure.mybatis.readservice;
 import io.spring.application.data.CommentData;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
 @Mapper
 public interface CommentReadService {
     CommentData findById(@Param("id") String id);

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/TagReadService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/TagReadService.java
@@ -1,11 +1,9 @@
 package io.spring.infrastructure.mybatis.readservice;
 
 import org.apache.ibatis.annotations.Mapper;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
 @Mapper
 public interface TagReadService {
     List<String> all();

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/UserReadService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/UserReadService.java
@@ -3,9 +3,7 @@ package io.spring.infrastructure.mybatis.readservice;
 import io.spring.application.data.UserData;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Component;
 
-@Component
 @Mapper
 public interface UserReadService {
 

--- a/src/main/java/io/spring/infrastructure/mybatis/readservice/UserRelationshipQueryService.java
+++ b/src/main/java/io/spring/infrastructure/mybatis/readservice/UserRelationshipQueryService.java
@@ -2,12 +2,10 @@ package io.spring.infrastructure.mybatis.readservice;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Set;
 
-@Component
 @Mapper
 public interface UserRelationshipQueryService {
     boolean isUserFollowing(@Param("userId") String userId, @Param("anotherUserId") String anotherUserId);


### PR DESCRIPTION
MyBatis mapper interface does not need `@Component`.