### PR TITLE
Fix dependencies to allow docker builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile('org.springframework.boot:spring-boot-starter-security')
 	compile('joda-time:joda-time:2.10')
     compileOnly('org.projectlombok:lombok')
+	annotationProcessor 'org.projectlombok:lombok:1.18.6'
 	runtime('com.h2database:h2')
     testCompile 'io.rest-assured:rest-assured:3.1.1'
 	testCompile 'io.rest-assured:spring-mock-mvc:3.1.1'


### PR DESCRIPTION
### Expected behavior

The docker build should run without errors.

### Actual behavior

There are errors while building the container. The Gradle build does not work because the getters and setters generated by Lombok are not recognized in the build process. For example: 
The method getId() is not found in User. The class user does not feature the method but it is annotated with @Getter. Therefore, such a method should exist. 

### How does this fix work

To generate the getters and setters Lombok needs step in the build process and handle the annotations like @Getter. This PR adds the missing annotation processor and follows the [Lombok documentation](https://projectlombok.org/setup/gradle).