### PR TITLE
Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,24 @@ It uses a H2 in memory database (for now), can be changed easily in the `applica
 
 # Getting started
 
-You need Java installed.
+You need Java 8 installed.
 
     ./gradlew bootRun
-    open http://localhost:8080
+
+To test that it works, open a browser tab at http://localhost:8080/tags .  
+Alternatively, you can run
+
+    curl http://localhost:8080/tags
 
 # Try it out with [Docker](https://www.docker.com/)
 
 You need Docker installed.
 	
 	docker-compose up -d
+
+# Try it out with a RealWorld frontend
+
+The entry point address of the backend API is at http://localhost:8080, **not** http://localhost:8080/api as some of the frontend documentation suggests.
 
 # Run test
 


### PR DESCRIPTION
The entry point URL of this backend is not consistent with others, it's not at `/api`. For a Spring web novice this is quite a challenge as all you see is HTTP status 401 (unauthorized). I have now made this explicit in the README, hopefully others won't have to go through the pain.
Also, the chosen gradle version does not work on Java 11.