### PR TITLE
Migrated deprecated asserts to more explicit junit asserts

### DIFF
--- a/src/test/java/io/spring/application/comment/CommentQueryServiceTest.java
+++ b/src/test/java/io/spring/application/comment/CommentQueryServiceTest.java
@@ -23,8 +23,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.List;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @MybatisTest
 @RunWith(SpringRunner.class)
@@ -45,24 +45,24 @@ public class CommentQueryServiceTest {
     private User user;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         user = new User("aisensiy@test.com", "aisensiy", "123", "", "");
         userRepository.save(user);
     }
 
     @Test
-    public void should_read_comment_success() throws Exception {
+    public void should_read_comment_success() {
         Comment comment = new Comment("content", user.getId(), "123");
         commentRepository.save(comment);
 
         Optional<CommentData> optional = commentQueryService.findById(comment.getId(), user);
-        assertThat(optional.isPresent(), is(true));
+        assertTrue(optional.isPresent());
         CommentData commentData = optional.get();
-        assertThat(commentData.getProfileData().getUsername(), is(user.getUsername()));
+        assertEquals(commentData.getProfileData().getUsername(), user.getUsername());
     }
 
     @Test
-    public void should_read_comments_of_article() throws Exception {
+    public void should_read_comments_of_article() {
         Article article = new Article("title", "desc", "body", new String[]{"java"}, user.getId());
         articleRepository.save(article);
 
@@ -76,7 +76,7 @@ public class CommentQueryServiceTest {
         commentRepository.save(comment2);
 
         List<CommentData> comments = commentQueryService.findByArticleId(article.getId(), user);
-        assertThat(comments.size(), is(2));
+        assertEquals(comments.size(), 2);
 
     }
 }

--- a/src/test/java/io/spring/application/profile/ProfileQueryServiceTest.java
+++ b/src/test/java/io/spring/application/profile/ProfileQueryServiceTest.java
@@ -14,8 +14,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @MybatisTest
@@ -27,12 +26,12 @@ public class ProfileQueryServiceTest {
     private UserRepository userRepository;
 
     @Test
-    public void should_fetch_profile_success() throws Exception {
+    public void should_fetch_profile_success() {
         User currentUser = new User("a@test.com", "a", "123", "", "");
         User profileUser = new User("p@test.com", "p", "123", "", "");
         userRepository.save(profileUser);
 
         Optional<ProfileData> optional = profileQueryService.findByUsername(profileUser.getUsername(), currentUser);
-        assertThat(optional.isPresent(), is(true));
+        assertTrue(optional.isPresent());
     }
 }

--- a/src/test/java/io/spring/application/tag/TagsQueryServiceTest.java
+++ b/src/test/java/io/spring/application/tag/TagsQueryServiceTest.java
@@ -11,8 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @MybatisTest
@@ -25,8 +24,8 @@ public class TagsQueryServiceTest {
     private ArticleRepository articleRepository;
 
     @Test
-    public void should_get_all_tags() throws Exception {
+    public void should_get_all_tags() {
         articleRepository.save(new Article("test", "test", "test", new String[]{"java"}, "123"));
-        assertThat(tagsQueryService.allTags().contains("java"), is(true));
+        assertTrue(tagsQueryService.allTags().contains("java"));
     }
 }

--- a/src/test/java/io/spring/core/article/ArticleTest.java
+++ b/src/test/java/io/spring/core/article/ArticleTest.java
@@ -8,31 +8,31 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ArticleTest {
 
     @Test
-    public void should_get_right_slug() throws Exception {
+    public void should_get_right_slug() {
         Article article = new Article("a new   title", "desc", "body", new String[]{"java"}, "123");
         assertThat(article.getSlug(), is("a-new-title"));
     }
 
     @Test
-    public void should_get_right_slug_with_number_in_title() throws Exception {
+    public void should_get_right_slug_with_number_in_title() {
         Article article = new Article("a new title 2", "desc", "body", new String[]{"java"}, "123");
         assertThat(article.getSlug(), is("a-new-title-2"));
     }
 
     @Test
-    public void should_get_lower_case_slug() throws Exception {
+    public void should_get_lower_case_slug() {
         Article article = new Article("A NEW TITLE", "desc", "body", new String[]{"java"}, "123");
         assertThat(article.getSlug(), is("a-new-title"));
     }
 
     @Test
-    public void should_handle_other_language() throws Exception {
+    public void should_handle_other_language() {
         Article article = new Article("中文：标题", "desc", "body", new String[]{"java"}, "123");
         assertThat(article.getSlug(), is("中文-标题"));
     }
 
     @Test
-    public void should_handle_commas() throws Exception {
+    public void should_handle_commas() {
         Article article = new Article("what?the.hell,w", "desc", "body", new String[]{"java"}, "123");
         assertThat(article.getSlug(), is("what-the-hell-w"));
     }

--- a/src/test/java/io/spring/infrastructure/article/ArticleRepositoryTransactionTest.java
+++ b/src/test/java/io/spring/infrastructure/article/ArticleRepositoryTransactionTest.java
@@ -12,8 +12,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -30,7 +29,7 @@ public class ArticleRepositoryTransactionTest {
 
 
     @Test
-    public void transactional_test() throws Exception {
+    public void transactional_test() {
         User user = new User("aisensiy@gmail.com", "aisensiy", "123", "bio", "default");
         userRepository.save(user);
         Article article = new Article("test", "desc", "body", new String[]{"java", "spring"}, user.getId());
@@ -39,7 +38,7 @@ public class ArticleRepositoryTransactionTest {
         try {
             articleRepository.save(anotherArticle);
         } catch (Exception e) {
-            assertThat(articleMapper.findTag("other"), is(false));
+            assertFalse(articleMapper.findTag("other"));
         }
     }
 

--- a/src/test/java/io/spring/infrastructure/article/MyBatisArticleRepositoryTest.java
+++ b/src/test/java/io/spring/infrastructure/article/MyBatisArticleRepositoryTest.java
@@ -17,9 +17,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 @MybatisTest
 @RunWith(SpringRunner.class)
@@ -35,24 +36,24 @@ public class MyBatisArticleRepositoryTest {
 
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         User user = new User("aisensiy@gmail.com", "aisensiy", "123", "bio", "default");
         userRepository.save(user);
         article = new Article("test", "desc", "body", new String[]{"java", "spring"}, user.getId());
     }
 
     @Test
-    public void should_create_and_fetch_article_success() throws Exception {
+    public void should_create_and_fetch_article_success() {
         articleRepository.save(article);
         Optional<Article> optional = articleRepository.findById(article.getId());
-        assertThat(optional.isPresent(), is(true));
-        assertThat(optional.get(), is(article));
-        assertThat(optional.get().getTags().contains(new Tag("java")), is(true));
-        assertThat(optional.get().getTags().contains(new Tag("spring")), is(true));
+        assertTrue(optional.isPresent());
+        assertEquals(optional.get(), article);
+        assertTrue(optional.get().getTags().contains(new Tag("java")));
+        assertTrue(optional.get().getTags().contains(new Tag("spring")));
     }
 
     @Test
-    public void should_update_and_fetch_article_success() throws Exception {
+    public void should_update_and_fetch_article_success() {
         articleRepository.save(article);
 
         String newTitle = "new test 2";
@@ -60,17 +61,17 @@ public class MyBatisArticleRepositoryTest {
         articleRepository.save(article);
         System.out.println(article.getSlug());
         Optional<Article> optional = articleRepository.findBySlug(article.getSlug());
-        assertThat(optional.isPresent(), is(true));
+        assertTrue(optional.isPresent());
         Article fetched = optional.get();
-        assertThat(fetched.getTitle(), is(newTitle));
-        assertThat(fetched.getBody(), not(""));
+        assertEquals(fetched.getTitle(), newTitle);
+        assertNotEquals(fetched.getBody(), "");
     }
 
     @Test
-    public void should_delete_article() throws Exception {
+    public void should_delete_article() {
         articleRepository.save(article);
 
         articleRepository.remove(article);
-        assertThat(articleRepository.findById(article.getId()).isPresent(), is(false));
+        assertFalse(articleRepository.findById(article.getId()).isPresent());
     }
 }

--- a/src/test/java/io/spring/infrastructure/comment/MyBatisCommentRepositoryTest.java
+++ b/src/test/java/io/spring/infrastructure/comment/MyBatisCommentRepositoryTest.java
@@ -12,8 +12,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @MybatisTest
 @RunWith(SpringRunner.class)
@@ -23,12 +23,12 @@ public class MyBatisCommentRepositoryTest {
     private CommentRepository commentRepository;
 
     @Test
-    public void should_create_and_fetch_comment_success() throws Exception {
+    public void should_create_and_fetch_comment_success() {
         Comment comment = new Comment("content", "123", "456");
         commentRepository.save(comment);
 
         Optional<Comment> optional = commentRepository.findById("456", comment.getId());
-        assertThat(optional.isPresent(), is(true));
-        assertThat(optional.get(), is(comment));
+        assertTrue(optional.isPresent());
+        assertEquals(optional.get(), comment);
     }
 }

--- a/src/test/java/io/spring/infrastructure/favorite/MyBatisArticleFavoriteRepositoryTest.java
+++ b/src/test/java/io/spring/infrastructure/favorite/MyBatisArticleFavoriteRepositoryTest.java
@@ -10,9 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringRunner.class)
 @MybatisTest
@@ -25,17 +24,17 @@ public class MyBatisArticleFavoriteRepositoryTest {
     private io.spring.infrastructure.mybatis.mapper.ArticleFavoriteMapper articleFavoriteMapper;
 
     @Test
-    public void should_save_and_fetch_articleFavorite_success() throws Exception {
+    public void should_save_and_fetch_articleFavorite_success() {
         ArticleFavorite articleFavorite = new ArticleFavorite("123", "456");
         articleFavoriteRepository.save(articleFavorite);
-        assertThat(articleFavoriteMapper.find(articleFavorite.getArticleId(), articleFavorite.getUserId()), notNullValue());
+        assertNotNull(articleFavoriteMapper.find(articleFavorite.getArticleId(), articleFavorite.getUserId()));
     }
 
     @Test
-    public void should_remove_favorite_success() throws Exception {
+    public void should_remove_favorite_success() {
         ArticleFavorite articleFavorite = new ArticleFavorite("123", "456");
         articleFavoriteRepository.save(articleFavorite);
         articleFavoriteRepository.remove(articleFavorite);
-        assertThat(articleFavoriteRepository.find("123", "456").isPresent(), is(false));
+        assertFalse(articleFavoriteRepository.find("123", "456").isPresent());
     }
 }

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -7,38 +7,39 @@ import org.junit.Test;
 
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultJwtServiceTest {
 
     private JwtService jwtService;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         jwtService = new DefaultJwtService("123123", 3600);
     }
 
     @Test
-    public void should_generate_and_parse_token() throws Exception {
+    public void should_generate_and_parse_token() {
         User user = new User("email@email.com", "username", "123", "", "");
         String token = jwtService.toToken(user);
-        assertThat(token, notNullValue());
+        assertNotNull(token);
         Optional<String> optional = jwtService.getSubFromToken(token);
-        assertThat(optional.isPresent(), is(true));
-        assertThat(optional.get(), is(user.getId()));
+        assertTrue(optional.isPresent());
+        assertEquals(optional.get(), user.getId());
     }
 
     @Test
-    public void should_get_null_with_wrong_jwt() throws Exception {
+    public void should_get_null_with_wrong_jwt() {
         Optional<String> optional = jwtService.getSubFromToken("123");
-        assertThat(optional.isPresent(), is(false));
+        assertFalse(optional.isPresent());
     }
 
     @Test
-    public void should_get_null_with_expired_jwt() throws Exception {
+    public void should_get_null_with_expired_jwt() {
         String token = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhaXNlbnNpeSIsImV4cCI6MTUwMjE2MTIwNH0.SJB-U60WzxLYNomqLo4G3v3LzFxJKuVrIud8D8Lz3-mgpo9pN1i7C8ikU_jQPJGm8HsC1CquGMI-rSuM7j6LDA";
-        assertThat(jwtService.getSubFromToken(token).isPresent(), is(false));
+        assertFalse(jwtService.getSubFromToken(token).isPresent());
     }
 }

--- a/src/test/java/io/spring/infrastructure/user/MyBatisUserRepositoryTest.java
+++ b/src/test/java/io/spring/infrastructure/user/MyBatisUserRepositoryTest.java
@@ -14,8 +14,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @MybatisTest
@@ -26,49 +27,49 @@ public class MyBatisUserRepositoryTest {
     private User user;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         user = new User("aisensiy@163.com", "aisensiy", "123", "", "default");
     }
 
     @Test
-    public void should_save_and_fetch_user_success() throws Exception {
+    public void should_save_and_fetch_user_success() {
         userRepository.save(user);
         Optional<User> userOptional = userRepository.findByUsername("aisensiy");
-        assertThat(userOptional.get(), is(user));
+        assertEquals(userOptional.get(), user);
         Optional<User> userOptional2 = userRepository.findByEmail("aisensiy@163.com");
-        assertThat(userOptional2.get(), is(user));
+        assertEquals(userOptional2.get(), user);
     }
 
     @Test
-    public void should_update_user_success() throws Exception {
+    public void should_update_user_success() {
         String newEmail = "newemail@email.com";
         user.update(newEmail, "", "", "", "");
         userRepository.save(user);
         Optional<User> optional = userRepository.findByUsername(user.getUsername());
-        assertThat(optional.isPresent(), is(true));
-        assertThat(optional.get().getEmail(), is(newEmail));
+        assertTrue(optional.isPresent());
+        assertEquals(optional.get().getEmail(), newEmail);
 
         String newUsername = "newUsername";
         user.update("", newUsername, "", "", "");
         userRepository.save(user);
         optional = userRepository.findByEmail(user.getEmail());
-        assertThat(optional.isPresent(), is(true));
-        assertThat(optional.get().getUsername(), is(newUsername));
-        assertThat(optional.get().getImage(), is(user.getImage()));
+        assertTrue(optional.isPresent());
+        assertEquals(optional.get().getUsername(), newUsername);
+        assertEquals(optional.get().getImage(), user.getImage());
     }
 
     @Test
-    public void should_create_new_user_follow_success() throws Exception {
+    public void should_create_new_user_follow_success() {
         User other = new User("other@example.com", "other", "123", "", "");
         userRepository.save(other);
 
         FollowRelation followRelation = new FollowRelation(user.getId(), other.getId());
         userRepository.saveRelation(followRelation);
-        assertThat(userRepository.findRelation(user.getId(), other.getId()).isPresent(), is(true));
+        assertTrue(userRepository.findRelation(user.getId(), other.getId()).isPresent());
     }
 
     @Test
-    public void should_unfollow_user_success() throws Exception {
+    public void should_unfollow_user_success() {
         User other = new User("other@example.com", "other", "123", "", "");
         userRepository.save(other);
 
@@ -76,6 +77,6 @@ public class MyBatisUserRepositoryTest {
         userRepository.saveRelation(followRelation);
 
         userRepository.removeRelation(followRelation);
-        assertThat(userRepository.findRelation(user.getId(), other.getId()).isPresent(), is(false));
+        assertFalse(userRepository.findRelation(user.getId(), other.getId()).isPresent());
     }
 }


### PR DESCRIPTION
Hi,

I have migrated majority of the tests from the hamcrest matchers to use the junit more explicit method calls

e.g `assertThat(someBool, is(true)) ` to `assertTrue(someBool)`

also removed unnecessary exception throws decelerations.