### PR TITLE
Dockerfile fixed: use gradlew instead of gradle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV GRADLE_USER_HOME /home/gradle/project
 
 COPY . /home/gradle/project
 
-RUN gradle build
+RUN ./gradlew build
 
 
 FROM java:jre-alpine


### PR DESCRIPTION
We should use gradlew instead of gradle to run the version specified in gradle-wrapper.properties.
This fixes #29 