### PR TITLE
Improve error handling for malformed JSON requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,11 @@ dependencies {
     implementation 'joda-time:joda-time:2.10.13'
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
 
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
+
+    testCompileOnly 'org.projectlombok:lombok:1.18.38'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.38'
 
     testImplementation 'io.rest-assured:rest-assured:4.5.1'
     testImplementation 'io.rest-assured:json-path:4.5.1'

--- a/src/main/java/io/spring/api/exception/CustomizeExceptionHandler.java
+++ b/src/main/java/io/spring/api/exception/CustomizeExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -106,4 +107,26 @@ public class CustomizeExceptionHandler extends ResponseEntityExceptionHandler {
       return String.join(".", Arrays.copyOfRange(splits, 2, splits.length));
     }
   }
+
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+
+        List<FieldErrorResource> errors = List.of(
+                new FieldErrorResource(
+                        "request",
+                        "body",
+                        "InvalidJson",
+                        "Invalid request format. Expected body wrapped in 'user' object."
+                )
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResource(errors));
+    }
 }


### PR DESCRIPTION
Adds a handler for HttpMessageNotReadableException to improve error messages when request body is malformed or missing required root object.